### PR TITLE
closes #34 . Enable diagnosing variables on inner grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ the latest version of the code, and publish them to `example` when commiting to 
 
 ## What's new
 
+### not released yet
+* Allow additional dimension names occurring when variables on inner grid are diagnosed, e.g. `x_grid_U_inner` or `x_grid_U`.
+
 ### v0.4.1 (2023-03-29)
 * Allow to open files if time bounds are missing
 * Minor bug correction for nemo 3.6 

--- a/xnemogcm/nemo.py
+++ b/xnemogcm/nemo.py
@@ -83,16 +83,16 @@ def nemo_preprocess(ds, domcfg, point_type=None):
         z_nme = None
 
     # get the name of the dimension along i e.g. x, x_grid_U, x_grid_U_inner etc
-    x_nme = [i for i in ds.dims.keys() if "x_grid" in i or i=='x']
+    x_nme = [i for i in ds.dims.keys() if "x_grid" in i or i == "x"]
     # get the name of the dimension along j e.g. y, y_grid_U, y_grid_U_inner etc
-    y_nme = [i for i in ds.dims.keys() if "y_grid" in i or i=='y']
-    
+    y_nme = [i for i in ds.dims.keys() if "y_grid" in i or i == "y"]
+
     for x in x_nme:
         to_rename.update({x: point.x})
 
     for y in y_nme:
         to_rename.update({y: point.y})
-    
+
     points = [point.x, point.y]
     if z_nme:
         to_rename.update({z_nme: point.z})

--- a/xnemogcm/nemo.py
+++ b/xnemogcm/nemo.py
@@ -81,21 +81,17 @@ def nemo_preprocess(ds, domcfg, point_type=None):
     except IndexError:
         # This means that there is no depth dependence of the data (surface data)
         z_nme = None
-    # get the name of the variable along i e.g. x, x_grid_U, x_grid_U_inner etc
-    try:
-        x_nme = [i for i in ds.dims.keys() if "x_grid" in i]
-    except IndexError:
-        # This means that the i-dimension must have the name 'x'
-        x_nme = ["x"]
-    # get the name of the variable along j e.g. y, y_grid_U, y_grid_U_inner etc
-    try:
-        y_nme = [i for i in ds.dims.keys() if "y_grid" in i]
-    except IndexError:
-        # This means that the j-dimension must have the name 'y'
-        y_nme = ["y"]
+
+    # get the name of the dimension along i e.g. x, x_grid_U, x_grid_U_inner etc
+    x_nme = [i for i in ds.dims.keys() if "x_grid" in i or i=='x']
+    # get the name of the dimension along j e.g. y, y_grid_U, y_grid_U_inner etc
+    y_nme = [i for i in ds.dims.keys() if "y_grid" in i or i=='y']
     
-    for x, y in zip(x_nme, y_nme):
-        to_rename.update({x: point.x, y: point.y})
+    for x in x_nme:
+        to_rename.update({x: point.x})
+
+    for y in y_nme:
+        to_rename.update({y: point.y})
     
     points = [point.x, point.y]
     if z_nme:

--- a/xnemogcm/nemo.py
+++ b/xnemogcm/nemo.py
@@ -81,9 +81,22 @@ def nemo_preprocess(ds, domcfg, point_type=None):
     except IndexError:
         # This means that there is no depth dependence of the data (surface data)
         z_nme = None
-    x_nme = "x"
-    y_nme = "y"
-    to_rename.update({x_nme: point.x, y_nme: point.y})
+    # get the name of the variable along i e.g. x, x_grid_U, x_grid_U_inner etc
+    try:
+        x_nme = [i for i in ds.dims.keys() if "x_grid" in i]
+    except IndexError:
+        # This means that the i-dimension must have the name 'x'
+        x_nme = ["x"]
+    # get the name of the variable along j e.g. y, y_grid_U, y_grid_U_inner etc
+    try:
+        y_nme = [i for i in ds.dims.keys() if "y_grid" in i]
+    except IndexError:
+        # This means that the j-dimension must have the name 'y'
+        y_nme = ["y"]
+    
+    for x, y in zip(x_nme, y_nme):
+        to_rename.update({x: point.x, y: point.y})
+    
     points = [point.x, point.y]
     if z_nme:
         to_rename.update({z_nme: point.z})


### PR DESCRIPTION
All of the following horizontal dimension names `x`/`y`,  `x_grid_...`/`y_grid_...` or `x_grid_..._inner`/`y_grid_..._inner` are now accepted and equally renamed. closes #34 