### PR TITLE
Add clarifying language to docs index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,13 +31,14 @@ grid = xgcm.Grid(ds, metrics=get_metrics(ds), periodic=False)
 ## Examples
 
 #### 1. [Open and process NEMO output with Xarray](examples/open_process_files)
-This example demonstrates how `xnemocgm` is able to open and process NEMO output as `xarray.Datasets` from an array of different storage locations. It also has multiple options for interpreting information about the variable grid points for use with `xgcm`. 
+This example demonstrates how `xnemocgm` is able to open and process NEMO output as `xarray.Datasets` from an array of different storage locations. Its main ability is to provide multiple options for interpreting information about the variable grid points for use with `xgcm`.
 
 #### 2. [Recombine NEMO output files](examples/recombing_mesh_mask_domain_cfg)
-The NEMO model outputs two files related to the domain grid that are relevant for interpretation by `xgcm`: the domain configuration file (`domain_cfg`) and the model mesh (`mesh_mask`). For most processing, it is necessary to combine these two files. This example shows how `xnemogcm` is able to recombine the `domain_cfg` and `mesh_mask` files, which removes the need to rely on the recombining tool from the Fortran NEMO toolbox.
+Two types of files related to the domain grid can be of use with NEMO: the `domain_cfg` files and the `mesh_mask` files. They are very similar, and any of them can be used by xnemogcm. If you are using a realistic (regional or global) configuration, they are provided as input files to NEMO so you should have these file. If you are using idealised configuration with analytical bathymetry, these files can be outputted by NEMO ([`ln_meshmask = .true.`](https://forge.nemo-ocean.eu/nemo/nemo/-/blob/4.2.0/cfgs/SHARED/namelist_ref?ref_type=tags#L80) or [`ln_write_cfg = .true.`](https://forge.nemo-ocean.eu/nemo/nemo/-/blob/4.2.0/cfgs/SHARED/namelist_ref?ref_type=tags#L92) in the namelist for the `mesh_mask` or the `domain_cfg`, respectively). 
+If `mesh_mask` or `domain_cfg` files are outputted by NEMO, they will be split between each processor, i.e. each processor will output only a subset of the whole file that corresponds to the space domain that the processor is handling. A Fortran toolbox is provided in NEMO to recombine these split files into a unified one, however `xnemogcm` is able to recombine the `domain_cfg` and `mesh_mask` files. This removes the need to rely on the recombining tool from the Fortran NEMO toolbox.
 
 #### 3. [Compute missing metrics](examples/compute_metrics)
-This example showcases how `xnemogcm` can compute certain missing metrics related to scale factors.
+This example showcases how `xnemogcm` can compute certain missing metrics (metrics are called scale factors in the NEMO community, and called metrics in the xgcm community).
 
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 ![pypi](https://badge.fury.io/py/xnemogcm.svg)
 ![anaconda badge](https://anaconda.org/conda-forge/xnemogcm/badges/version.svg)
 
-Interface to open NEMO ocean global circulation model output dataset and create a xgcm grid.
+Interface to open NEMO ocean global circulation model output as an [Xarray](https://docs.xarray.dev/en/stable/) Dataset and create a [xgcm](https://xgcm.readthedocs.io/en/latest/) grid. 
 NEMO 3.6, 4.0, and 4.2.0 are tested and supported. Any version between 3.6 and 4.2.0 should work,
 but in case of trouble, [please open an issue](https://github.com/rcaneill/xnemogcm/issues).
 
@@ -30,17 +30,14 @@ grid = xgcm.Grid(ds, metrics=get_metrics(ds), periodic=False)
 
 ## Examples
 
-`xnemocgm` is able to process xarray.Datasets (e.g. they could be retrieved from a remote server),
-and can get information of the variables grid points with multiple options:
-see [examples/open_process_files](examples/open_process_files).
+#### 1. [Open and process NEMO output with Xarray](examples/open_process_files)
+This example demonstrates how `xnemocgm` is able to open and process NEMO output as `xarray.Datasets` from an array of different storage locations. It also has multiple options for interpreting information about the variable grid points for use with `xgcm`. 
 
-`xnemogcm` is capable or recombining the domain_cfg and mesh_mask files output
-by multiple processors,
-the recombining tool from the NEMO toolbox is thus not needed here: see
-[examples/recombing_mesh_mask_domain_cfg](examples/recombing_mesh_mask_domain_cfg).
+#### 2. [Recombine NEMO output files](examples/recombing_mesh_mask_domain_cfg)
+The NEMO model outputs two files related to the domain grid that are relevant for interpretation by `xgcm`: the domain configuration file (`domain_cfg`) and the model mesh (`mesh_mask`). For most processing, it is necessary to combine these two files. This example shows how `xnemogcm` is able to recombine the `domain_cfg` and `mesh_mask` files, which removes the need to rely on the recombining tool from the Fortran NEMO toolbox.
 
-`xnemogcm` has a minimum capability of computing missing metrics
-(scale factors): see [examples/compute_metrics](examples/compute_metrics).
+#### 3. [Compute missing metrics](examples/compute_metrics)
+This example showcases how `xnemogcm` can compute certain missing metrics related to scale factors.
 
 
 ## Installation


### PR DESCRIPTION
In general, I think the documentation of this package could be made a bit clearer. I make a few suggestions in this PR, particularly around the language used to describe the 3 examples. However, I haven't used NEMO data myself, so please review the wording I used and ensure that it is correct.

My main issue with this docs index page is that it assumes a high level of NEMO knowledge. I understand that most people who use this tool will be well-versed in the output files and structures of NEMO, but with just a little effort, these docs can also be helpful for people who are new to using NEMO. 

For example, I don't actually know why it's important to "recombine" the domain_cfg and mesh_mask files (Example 2). I took a stab at explaining why this is necessary in this PR, but just a sentence motivating why this is useful for users would be very helpful. 