### PR TITLE
modify condition to get t_bounds variable

### DIFF
--- a/xnemogcm/nemo.py
+++ b/xnemogcm/nemo.py
@@ -103,12 +103,15 @@ def nemo_preprocess(ds, domcfg, point_type=None):
     # rename time and space
     # get time_counter bounds
     time_b = ds["time_counter"].attrs.get("bounds")
-    if time_b:
+    if time_b and time_b in ds:
         to_rename.update({"time_counter": "t", time_b: "t_bounds"})
     else:
         to_rename.update({"time_counter": "t"})
+        if not time_b in ds:
+            ds["time_counter"].attrs.pop("bounds")
+            time_b = None
     ds = ds.rename(to_rename)
-    if time_b:
+    if time_b and "t_bounds" in ds:
         ds["t"].attrs["bounds"] = "t_bounds"
     # setting z_c/z_f/x_c/etc to be the same as in domcfg
     ds = ds.assign_coords({i: domcfg[i] for i in points})

--- a/xnemogcm/nemo.py
+++ b/xnemogcm/nemo.py
@@ -107,7 +107,7 @@ def nemo_preprocess(ds, domcfg, point_type=None):
         to_rename.update({"time_counter": "t", time_b: "t_bounds"})
     else:
         to_rename.update({"time_counter": "t"})
-        if not time_b in ds:
+        if time_b not in ds:
             ds["time_counter"].attrs.pop("bounds")
             time_b = None
     ds = ds.rename(to_rename)

--- a/xnemogcm/test/test_nemo.py
+++ b/xnemogcm/test/test_nemo.py
@@ -158,7 +158,7 @@ def test_use_preprocess_no_time_bound(data_path):
     ds = nemo_preprocess(ds_raw, domcfg)
     assert "x_c" in ds
     assert "t" in ds
-    assert ds["t"].attrs.get("bounds") is None
+    '''assert ds["t"].attrs.get("bounds") is None'''
 
 def test_coordinates_horizontal(data_path):
     """Test that coordinates are added to nemo files"""

--- a/xnemogcm/test/test_nemo.py
+++ b/xnemogcm/test/test_nemo.py
@@ -146,7 +146,8 @@ def test_use_preprocess(data_path):
     ds = nemo_preprocess(ds_raw, domcfg)
     assert "x_c" in ds
     assert "t" in ds
-    
+
+
 def test_use_preprocess_no_time_bound(data_path):
     """Test that if the time_bound variable does not exist, no error is raised"""
     domcfg = open_domain_cfg(

--- a/xnemogcm/test/test_nemo.py
+++ b/xnemogcm/test/test_nemo.py
@@ -160,6 +160,7 @@ def test_use_preprocess_no_time_bound(data_path):
     assert "t" in ds
     assert ds["t"].attrs.get("bounds") is None
 
+
 def test_coordinates_horizontal(data_path):
     """Test that coordinates are added to nemo files"""
     domcfg = open_domain_cfg(

--- a/xnemogcm/test/test_nemo.py
+++ b/xnemogcm/test/test_nemo.py
@@ -146,7 +146,19 @@ def test_use_preprocess(data_path):
     ds = nemo_preprocess(ds_raw, domcfg)
     assert "x_c" in ds
     assert "t" in ds
-
+    
+def test_use_preprocess_no_time_bound(data_path):
+    """Test that if the time_bound variable does not exist, no error is raised"""
+    domcfg = open_domain_cfg(
+        datadir=data_path / "mesh_mask_1_file",
+    )
+    ds_raw = xr.open_dataset(data_path / "nemo/GYRE_1y_00010101_00011230_grid_T.nc")
+    ds_raw.encoding["source"] = "GYRE_1y_00010101_00011230_grid_T.nc"
+    ds_raw = ds_raw.drop_vars(ds_raw["time_counter"].attrs.get("bounds"))
+    ds = nemo_preprocess(ds_raw, domcfg)
+    assert "x_c" in ds
+    assert "t" in ds
+    assert ds["t"].attrs.get("bounds") is None
 
 def test_coordinates_horizontal(data_path):
     """Test that coordinates are added to nemo files"""

--- a/xnemogcm/test/test_nemo.py
+++ b/xnemogcm/test/test_nemo.py
@@ -158,7 +158,7 @@ def test_use_preprocess_no_time_bound(data_path):
     ds = nemo_preprocess(ds_raw, domcfg)
     assert "x_c" in ds
     assert "t" in ds
-    '''assert ds["t"].attrs.get("bounds") is None'''
+    assert ds["t"].attrs.get("bounds") is None
 
 def test_coordinates_horizontal(data_path):
     """Test that coordinates are added to nemo files"""


### PR DESCRIPTION
Some CDFTOOLs do not conserve the t_bounds variable but conserves the attribute, and thus xnemogcm fails when trying to get it. 